### PR TITLE
Build process tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,17 +35,32 @@ What it doesn't do yet (maybe something you'd like to work on 🤔):
 
 First, make sure you have the WebAssembly toolchain installed and activated — see the ["Getting Started" guide](http://webassembly.org/getting-started/developers-guide) for details.
 
-Start by cloning this repo (the `--recursive` option also grabs the MRuby submodule and initializes it):
+Start by installing this gem:
 
 ```
-git clone --recursive https://github.com/blacktm/ruby-wasm.git
+gem install wasm
 ```
-
-`cd` into the directory. Notice there's a file called `hello.rb` — we're going to build it for WebAssembly!
 
 Make sure you have this `wasm` gem installed. Remember, you can check for issues using `ruby-wasm doctor`
 
-Now, we'll build (or compile) the "Hello Ruby!" app using:
+Then create a test dir for some example Ruby code:
+
+```
+mkdir ruby-wasm-test
+cd ruby-wasm-test
+echo 'puts "#{MRUBY_DESCRIPTION}"' > hello.rb
+```
+
+If you've installed using `gem`, you won't have a working mruby library, so run:
+
+```
+ruby-wasm vendor_mruby
+ruby-wasm build_mruby
+```
+
+This will create a dir called 'mruby' with the emscripten-compatible build_config.rb copied over. You can edit this to ie. include more mrb-gems in your build.
+
+Now we'll finally compile that Ruby file for the browser:
 
 ```
 ruby-wasm build hello.rb

--- a/bin/ruby-wasm
+++ b/bin/ruby-wasm
@@ -39,15 +39,17 @@ def build(rb_file)
   print "\nCompiling #{rb_file}..."
 
   # Create MRuby bytecode from Ruby source file
-  `mrbc -Bruby_app -obuild/app.c #{rb_file}`
+  cmd("#{mrbc} -Bruby_app -obuild/app.c #{rb_file}")
 
   # Add MRuby init code to app bytecode
   open('build/app.c', 'a') do |f|
     f << "\n\n" << File.read("#{@gem_dir}/assets/mruby_init.c")
   end
 
+  include_dir = @gem_dir + '/assets/mruby/include'
+  libmruby = first_extant_file( "./mruby/build/emscripten/lib/libmruby.a" , ENV["LIBMRUBY"] , @gem_dir + '/assets/mruby/libmruby.a' )
   # Compile using Emscripten
-  `emcc -s WASM=1 #{ if @optimize then '-Os' end } -I #{@gem_dir + '/assets/mruby/include'} build/app.c #{@gem_dir + '/assets/mruby/libmruby.a'} -o build/app.js #{ if @optimize then '--closure 1' end }`
+  cmd("emcc -s WASM=1 #{ if @optimize then '-Os' end } -I #{include_dir} build/app.c #{libmruby} -o build/app.js #{ if @optimize then '--closure 1' end }")
 
   # Copy HTML template from gem assets to build directory
   FileUtils.cp "#{@gem_dir}/assets/template.html", 'build/app.html'
@@ -147,6 +149,26 @@ def doctor(mode = nil)
   errors
 end
 
+def vendor_mruby
+  if File.exist?("#{@gem_dir}/mruby/README.md")
+    Dir.mkdir('mruby')
+    FileUtils.cp_r "#{@gem_dir}/mruby", "."
+    FileUtils.cp "#{@gem_dir}/build_config.rb", "./mruby/build_config.rb"
+  else
+    puts "Gem was checked out without submodules, cannot vendor mruby"
+    puts "Try these commands yourself:"
+    puts "  git clone https://github.com/mruby/mruby"
+    puts "  cp #{@gem_dir}/build_config.rb ./mruby/build_config.rb"
+    exit 1
+  end
+end
+
+def compile_mruby
+  Dir.chdir('mruby') do
+    system 'rake'
+  end
+end
+
 # Check Command-line Arguments #################################################
 
 usage = 'Ruby on WebAssembly'.bold + "\n
@@ -159,6 +181,8 @@ Summary of commands and options:
   serve              Serve the build WebAssembly binary
     -o|--open          Open the default web browser after serving
   doctor             Check for problems with your WebAssembly toolchain
+  vendor_mruby       Copy mruby source code into ./mruby
+  compile_mruby      Compile mruby from ./mruby
   -v|--version       Prints the installed version\n\n"
 
 case ARGV[0]
@@ -174,6 +198,10 @@ when 'serve'
   end
 when 'doctor'
   doctor
+when 'vendor_mruby'
+  vendor_mruby
+when 'compile_mruby'
+  compile_mruby
 when '-v', '--version'
   puts WASM::VERSION
 else

--- a/bin/ruby-wasm
+++ b/bin/ruby-wasm
@@ -9,14 +9,6 @@ require 'wasm/version'
 # Compilation optimizations flag
 @optimize = false
 
-# Extending `String` to include some fancy colors
-class String
-  def colorize(c); "\e[#{c}m#{self}\e[0m" end
-  def bold;  colorize('1')    end
-  def success; colorize('1;32') end
-  def error; colorize('1;31') end
-end
-
 def first_extant_file(*files)
   files.each do |file|
     if File.exist?( File.expand_path(file || "") )
@@ -57,6 +49,8 @@ def build(rb_file)
 
   # Create the build directory
   FileUtils.mkdir_p 'build'
+
+  print "\nCompiling #{rb_file}..."
 
   mrbc = first_extant_file( "./mruby/build/host/bin/mrbc" , ENV["MRBC"] , "mrbc")
   # Create MRuby bytecode from Ruby source file

--- a/bin/ruby-wasm
+++ b/bin/ruby-wasm
@@ -9,6 +9,28 @@ require 'wasm/version'
 # Compilation optimizations flag
 @optimize = false
 
+# Extending `String` to include some fancy colors
+class String
+  def colorize(c); "\e[#{c}m#{self}\e[0m" end
+  def bold;  colorize('1')    end
+  def success; colorize('1;32') end
+  def error; colorize('1;31') end
+end
+
+def first_extant_file(*files)
+  files.each do |file|
+    if File.exist?( File.expand_path(file || "") )
+      return file
+    end
+  end
+  return files[-1]
+end
+
+def cmd(str)
+  # puts str
+  `#{str}`
+end
+
 # Build a Ruby file
 def build(rb_file)
 
@@ -36,8 +58,7 @@ def build(rb_file)
   # Create the build directory
   FileUtils.mkdir_p 'build'
 
-  print "\nCompiling #{rb_file}..."
-
+  mrbc = first_extant_file( "./mruby/build/host/bin/mrbc" , ENV["MRBC"] , "mrbc")
   # Create MRuby bytecode from Ruby source file
   cmd("#{mrbc} -Bruby_app -obuild/app.c #{rb_file}")
 
@@ -147,6 +168,26 @@ def doctor(mode = nil)
   end
 
   errors
+end
+
+def vendor_mruby
+  if File.exist?("#{@gem_dir}/mruby/README.md")
+    Dir.mkdir('mruby')
+    FileUtils.cp_r "#{@gem_dir}/mruby", "."
+    FileUtils.cp "#{@gem_dir}/build_config.rb", "./mruby/build_config.rb"
+  else
+    puts "Gem was checked out without submodules, cannot vendor mruby"
+    puts "Try these commands yourself:"
+    puts "  git clone https://github.com/mruby/mruby"
+    puts "  cp #{@gem_dir}/build_config.rb ./mruby/build_config.rb"
+    exit 1
+  end
+end
+
+def compile_mruby
+  Dir.chdir('mruby') do
+    system 'rake'
+  end
 end
 
 def vendor_mruby


### PR DESCRIPTION
Hey there,
First off, thanks for your work on this, it's a pretty exciting idea to be able to use MRuby in browsers.

I did have a few issues getting started with it, especially when it was installed using `gem install`, which doesn't checkout the mruby submodule. I did find the current instructions a bit confusing as to which parts of the building/using/examples instructions needed to happen in the gem dir vs. my own project dir, and was not able to get it to recompile with different gems.

I also found it desirable to use a vendored version of mruby for each project, instead of having the gem provide it. This allows for different mruby-gems and build settings per-project.

I've made a few tweaks to allow using a vendored, easily-tweakable mruby install for each project, and updated the readme to reflect the instructions that got me started properly with it. Let me know how this looks, or if you'd like any changes made. Thanks again!